### PR TITLE
Fixed default engine for Unix.

### DIFF
--- a/source/eschecs.pas
+++ b/source/eschecs.pas
@@ -9,7 +9,7 @@ program Eschecs;
 {$DEFINE UseCThreads}
 
 uses
-  {$IFDEF UNIX}
+{$IFDEF UNIX}
   cthreads, 
   cwstring, 
 {$ENDIF}

--- a/source/eschecs.prj
+++ b/source/eschecs.prj
@@ -19,7 +19,7 @@ order16=0
 [projectoptions]
 projectdir=/home/fred/eschecs/source
 projectfilename=/home/fred/eschecs/source/eschecs.prj
-findinfiledialog=57
+findinfiledialog=58
  [findinfileadialogfo.subdirs]
  value=1
  [findinfileadialogfo.incurrentfile]
@@ -29,11 +29,11 @@ findinfiledialog=57
  [findinfileadialogfo.wholeword]
  value=0
  [findinfileadialogfo.inprojectdir]
- value=0
+ value=1
  [findinfileadialogfo.casesensitive]
  value=0
  [findinfileadialogfo.indirectories]
- value=1
+ value=0
  [findinfileadialogfo.mask]
  value="*.pas" "*.pp" "*.inc" 
  history=3
@@ -55,8 +55,9 @@ findinfiledialog=57
  filefilterindex=0
  filefilter="*.pas" "*.pp" "*.inc" "*.*"
  [findinfileadialogfo.findtext]
- value=fpg_form
- history=14
+ value=tprocess
+ history=15
+  tprocess
   fpg_form
   workingDirectory
   vEngines
@@ -194,7 +195,7 @@ options=114
  index=0
  [projectoptionsfo.setting_tab]
  firsttab=0
- index=0
+ index=2
  [projectoptionsfo]
  stackedunder=
  x=323
@@ -240,7 +241,7 @@ objpref=-Fo
 targpref=-o
 befcommand=0
 aftcommand=0
-makeoptions=9
+makeoptions=10
  -l -Mobjfpc -Schi
  -FE.
  -FUunits
@@ -249,8 +250,9 @@ makeoptions=9
  -O2 -XX -Xs -CX
  -dDEBUG
  -dBGRABITMAP_USE_FPGUI
+ -dOPT_HIGHLIGHT
  -vewnhibq
-makeoptpurpose=9
+makeoptpurpose=10
  Define Object Pascal
  Exe path to /.
  Output to /units
@@ -259,6 +261,7 @@ makeoptpurpose=9
  Optimizations
  Debug
  BGRABITMAP
+ 
  Verbosity
 compilerused=29
  ${COMPILER} (Default)
@@ -434,14 +437,15 @@ modulenames=0
 moduletypes=0
 modulefiles=0
 befcommandon=0
-makeoptionson=9
+makeoptionson=10
  4095
  4095
  4095
- 4024
- 118
+ 3896
+ 246
  4084
- 3971
+ 3843
+ 4095
  4095
  4091
 compilerusedon=29
@@ -773,8 +777,9 @@ envvarons=0
 [edit]
 hintwidth=462
 hintheight=214
-finddtext=THandle
+finddtext=DEFAULT_EXEPATH
 findhistory=20
+ DEFAULT_EXEPATH
  THandle
  System.THandle 
  cns_
@@ -784,7 +789,6 @@ findhistory=20
  SetCurrentDir
  aexepath
  DSTCOPY
- DEFAULT_EXEPATH
  aExePath
  ReadFromINIFile
  \
@@ -796,18 +800,28 @@ findhistory=20
  res=
  30005
 findoptions=1
-editpos=2
+editpos=4
+ 0,-1073741823
+ 0,39
+ 0,-1073741823
  0,0
- 0,264
 bookmarks0=0
 bookmarks1=0
-sourcefiles=2
+bookmarks2=0
+bookmarks3=0
+sourcefiles=4
  ${PROJECTDIR}/eschecs.pas
- /home/fred/eschecs/libraries/bgrabitmap/bgrafpguibitmap.pas
-relpaths=2
+ ${PROJECTDIR}/settings.pas
+ ${PROJECTDIR}/connect.pas
+ ${PROJECTDIR}/eschecs.pas
+relpaths=4
  eschecs.pas
- libraries/bgrabitmap/bgrafpguibitmap.pas
-ismoduletexts=2
+ settings.pas
+ connect.pas
+ eschecs.pas
+ismoduletexts=4
+ 0
+ 0
  0
  0
 modules=0
@@ -815,10 +829,15 @@ moduleoptions=0
 visiblemodules=0
 nomenumodules=0
 [sourcefo.files_tab]
+order=4
+ 0
+ 1
+ 3
+ 2
 firsttab=0
-index=1
+index=2
 [layout]
-windowlayout=585
+windowlayout=560
  [mainfo.basedock]
  splitdir=2
  useroptions=268450944
@@ -1293,8 +1312,10 @@ windowlayout=585
  [debuggerfo.edit_compiler]
  value=Pascal
  [debuggerfo.file_history]
- value=/home/fred/eschecs/libraries/bgrabitmap/bgrafpguibitmap.pas
- history=50
+ value=/home/fred/eschecs/source/eschecs.pas
+ history=20
+  /home/fred/eschecs/source/settings.pas
+  /home/fred/eschecs/libraries/bgrabitmap/bgrafpguibitmap.pas
   /home/fred/eschecs (copy 1)/source/eschecs.pas
   /home/fred/eschecs/source/eschecs.pas
   /home/fred/uos/examples/deviceinfos_fpGUI.pas
@@ -1313,38 +1334,6 @@ windowlayout=585
   /home/fred/fpGUI-ultibo/examples/corelib/aggcanvas/agg_canvas_test_ultibo.lpr
   /home/fred/fpGUI-ultibo/examples/corelib/canvastest/fpgcanvas_ultibo.lpr
   /home/fred/fpGUI-ultibo/examples/corelib/aggcanvas/agg_canvas_test.lpr
-  /home/fred/fpGUI-ultibo/examples/corelib/helloworld/build_ultibo.bat
-  /home/fred/eschecs/source/validator/validator.pas
-  /home/fred/uoslib/src/uoslib.pas
-  /home/fred/eschecs/source/sound_uos.pas
-  /home/fred/eschecs/source/sound.pas
-  /home/fred/eschecs/source/chessboard.pas
-  /home/fred/moustique/validator_dyn.pas
-  /home/fred/moustique/parser.pas
-  /home/fred/fpGUI-maint/examples/corelib/aggcanvas/agg_canvas_test.pas
-  /home/fred/fpGUI-maint/examples/corelib/aggcanvas/agg_canvas_test.lpr
-  /home/fred/fpGUI-maint/examples/corelib/aggcanvas/agg_canvas_test.lpi
-  /home/fred/designer_ext/src/designer_ext.pas
-  /home/fred/designer_ext/src/runonce_postit.pas
-  /home/fred/designer_ext/src/cthreads.pas
-  /home/fred/designer_ext/src/pthreads.pp
-  /home/fred/designer_ext/src/frm_multiselect.pas
-  /home/fred/designer_ext/src/fpg_style_anim_chrome_silver_vert_flatmenu.pas
-  /home/fred/designer_ext/src/plugmanager.pas
-  /home/fred/designer_ext/src/runonce_postit2.pas
-  /home/fred/ideu/src/plugmanager.pas
-  /home/fred/ideu/src/conffpgui.pas
-  /home/fred/ideu/src/confideu.pas
-  /home/fred/ideu/src/ideusettings.pas
-  /home/fred/ideu/src/make.pas
-  /home/fred/designer_ext/src/frm_colorpicker.pas
-  /home/fred/designer_ext/src/fpg_main.pas
-  /home/fred/designer_ext/src/develop_dynX11/fpg_main.pas
-  /home/fred/fpGUI-develop/src/corelib/fpg_main.pas
-  /home/fred/designer_ext/src/maint_dynX11/fpg_main.pas
-  /home/fred/designer_ext/src/runonce_postitold.pas
-  /home/fred/fpGUI-maint/src/corelib/fpg_main.pas
-  /home/fred/fpGUI-maint/src/corelib/fpg_base.pas
  [debuggerfo.project_options]
  value=5
  [debuggerfo.hints]
@@ -1366,8 +1355,13 @@ windowlayout=585
  rcx=0
  rcy=0
  [sourcefo.files_tab]
+ order=4
+  0
+  1
+  3
+  2
  firsttab=0
- index=1
+ index=2
  [cpuc86_64fo]
  irqoff=0
  splitdir=0

--- a/source/settings.pas
+++ b/source/settings.pas
@@ -37,7 +37,7 @@ const
   {$IFDEF WINDOWS}
   DEFAULT_EXEPATH = 'engines\fruit\fruit_21.exe';
   {$else}
-  DEFAULT_EXEPATH = '/home/fred/eschecs/source/engines/moustique/01/moustique';
+  DEFAULT_EXEPATH = '/engines/moustique/0.1/moustique';
   {$ENDIF}
   
   DEFAULT_HISTORY = '';


### PR DESCRIPTION
Hello Roland.

I think that now the conversion to Unix compatibility is ok.
There is one thing I have doubts.

It is about the directory name that you choose for moustique engine:
/engines/moustique/**0.1**/moustique

I am not sure that /0.1/  will be without problems because the use of the dot ( le point ).
IMHO it would be safer to not use dot for name of directory.

Maybe you could use /01/ (without dot) as name.

Fre;D 
