### PR TITLE
Some checks to make Eschecs more errors friendly (message if errors).

### DIFF
--- a/source/eschecs.prj
+++ b/source/eschecs.prj
@@ -470,13 +470,13 @@ makeoptionson=12
  4095
  4095
  4095
- 3844
+ 3908
  4032
  248
  4092
- 3907
+ 3843
  4095
- 4027
+ 4095
  4095
  4095
 compilerusedon=29
@@ -804,8 +804,10 @@ envvarons=0
 [edit]
 hintwidth=462
 hintheight=214
-finddtext=filestream
+finddtext=txColoring
 findhistory=20
+ txColoring
+ ShowMessagefrm
  filestream
  100 %
  OtherItemClicked
@@ -824,21 +826,34 @@ findhistory=20
  vConfigFilesPath
  .ini
  .json
- ShowMessagefrm
- GetText
 findoptions=1
-editpos=2
- 0,6
- 0,0
+editpos=5
+ 10,693
+ 0,8
+ 0,7
+ 0,651
+ 0,15
 bookmarks0=0
 bookmarks1=0
-sourcefiles=2
+bookmarks2=0
+bookmarks3=0
+bookmarks4=0
+sourcefiles=5
  ${PROJECTDIR}/eschecs.pas
  ${PROJECTDIR}/sound.pas
-relpaths=2
+ ${PROJECTDIR}/log.pas
+ /home/fred/eschecs_errorfriend/source/eschecs.pas
+ /home/fred/eschecs_errorfriend/source/log.pas
+relpaths=5
  eschecs.pas
  sound.pas
-ismoduletexts=2
+ log.pas
+ ../eschecs_errorfriend/source/eschecs.pas
+ ../eschecs_errorfriend/source/log.pas
+ismoduletexts=5
+ 0
+ 0
+ 0
  0
  0
 modules=0
@@ -846,10 +861,16 @@ moduleoptions=0
 visiblemodules=0
 nomenumodules=0
 [sourcefo.files_tab]
+order=5
+ 0
+ 3
+ 2
+ 4
+ 1
 firsttab=0
-index=1
+index=0
 [layout]
-windowlayout=585
+windowlayout=591
  [mainfo.basedock]
  splitdir=2
  useroptions=268450944
@@ -889,7 +910,7 @@ windowlayout=585
  rcy=0
  wsize=0
  active=0
- visible=0
+ visible=1
  [threadsfo]
  splitdir=0
  useroptions=268451945
@@ -1100,7 +1121,7 @@ windowlayout=585
  [symbolfo]
  splitdir=0
  useroptions=268451963
- stackedunder=mainfo
+ stackedunder=targetconsolefo
  parent=
  mdistate=0
  nx=0
@@ -1324,15 +1345,17 @@ windowlayout=585
  [debuggerfo.edit_compiler]
  value=Pascal
  [debuggerfo.file_history]
- value=/home/fred/eschecs/source/sound.pas
+ value=/home/fred/eschecs/source/eschecs.pas
  history=50
+  /home/fred/eschecs_errorfriend/source/eschecs.pas
+  /home/fred/eschecs/source/log.pas
+  /home/fred/eschecs/source/messagefrm.pas
+  /home/fred/eschecs/source/board.pas
+  /home/fred/eschecs/source/sound.pas
   /home/fred/eschecs/source/language.pas
   /home/fred/eschecs_uos2/source/eschecs.pas
   /home/fred/uos/examples/simpleplayer_fpGUI.pas
-  /home/fred/eschecs/source/sound.pas
   /home/fred/eschecs/libraries/uos/define.inc
-  /home/fred/eschecs/source/board.pas
-  /home/fred/eschecs/source/messagefrm.pas
   /home/fred/eschecs/libraries/uos/uos_flat.pas
   /home/fred/eschecs/libraries/uos/uos.pas
   /home/fred/uos/examples/consoleplaymemorystream.pas
@@ -1374,8 +1397,6 @@ windowlayout=585
   /home/fred/eschecs/source/images.pas
   /home/fred/eschecs/libraries/bgrabitmap/bgrabitmap.pas
   /home/fred/moustique_git/moustique/version.inc
-  /home/fred/ideu/README.TXT
-  /home/fred/ideu/src/mseconsts.pas
  [debuggerfo.project_options]
  value=1
  [debuggerfo.hints]
@@ -1397,8 +1418,14 @@ windowlayout=585
  rcx=0
  rcy=0
  [sourcefo.files_tab]
+ order=5
+  0
+  3
+  2
+  4
+  1
  firsttab=0
- index=1
+ index=0
  [cpuc86_64fo]
  irqoff=0
  splitdir=0

--- a/source/log.pas
+++ b/source/log.pas
@@ -10,31 +10,17 @@ type
   TLog = class
     class procedure Append(const aLine: string);
   end;
-
-implementation
-
+  
 var
   vLog: text;
+  VFileName: string;  
+
+implementation
 
 class procedure TLog.Append(const aLine: string);
 begin
   WriteLn(vLog, DateTimeToStr(Now()) + ' ' + aLine);
   Flush(vLog);
 end;
-
-var
-  VFileName: string;
-  
-initialization
-  vFileName := vLOGPath;
-  Assign(vLog, vFileName);
-  if FileExists(vFileName) then
-    Append(vLog)
-  else
-    Rewrite(vLog);
-    
-finalization
-  Close(vLog);
-  
   
 end.

--- a/source/messagefrm.pas
+++ b/source/messagefrm.pas
@@ -32,7 +32,7 @@ type
 {$define read_interface}
 {$undef read_implementation}
 
- procedure ShowMessageFrm(AMessage1, AMessage2, ATitle : string);
+ procedure ShowMessageFrm(AMessage1, AMessage2, ATitle, AButton : string);
 
 {$I icon.inc} 
 
@@ -44,7 +44,7 @@ begin
 close;
 end;
 
-procedure ShowMessageFrm(AMessage1, AMessage2, ATitle : string);
+procedure ShowMessageFrm(AMessage1, AMessage2, ATitle, AButton : string);
 var
 mwidth: integer;
 msgfrm : Tmessagefrm;
@@ -53,7 +53,7 @@ begin
   
 msgfrm :=  Tmessagefrm.create(nil);
   try
-    msgfrm.Button1.text := GetText(txQuit);
+    msgfrm.Button1.text := Abutton;
     msgfrm.label1.text := AMessage1;
     msgfrm.label2.text := AMessage2;
 

--- a/source/sound.pas
+++ b/source/sound.pas
@@ -35,10 +35,11 @@ const
   
 var
  ms :  array[0..5] of Tmemorystream; 
+ isloaded : boolean = false;
 
 procedure Play(const aSound: integer);
 begin
-uos_PlayNoFree(aSound);
+if isloaded then uos_PlayNoFree(aSound);
 end;
 
 function LoadSoundLib() : integer;
@@ -48,7 +49,7 @@ var
 begin
  vaudir := ExtractFilePath(ParamStr(0)) + 'audio' + directoryseparator ;
  vsodir := vaudir +  'sound' + directoryseparator;
-
+ 
  {$IFDEF Windows}
     {$if defined(cpu64)}
     PA_FileName := vaudir + 'lib\Windows\64bit\LibPortaudio-64.dll';
@@ -82,7 +83,8 @@ begin
   
 // Load the libraries, here only PortAudio and Mpg123
   result := uos_LoadLib(Pchar(PA_FileName), nil, Pchar(MP_FileName), nil, nil,  nil) ;
- 
+
+if result > -1 then begin 
 // using memorystream
 for x := 0 to 5 do
 begin
@@ -98,7 +100,8 @@ uos_AddIntoDevOut(x, -1, 0.03, -1, -1, 0, 1024, -1);
  {$endif}
 uos_OutputAddDSPVolume(x, 0, 1, 1); 
 end;
-
+isloaded := true;
+end;
 {$IFDEF OPT_DEBUG}
    WriteLn('Result of uos_LoadLib(): ' + inttostr(result));
 {$ENDIF}
@@ -108,7 +111,7 @@ procedure SetSoundVolume(vol : shortint);
 var
 x : integer;
 begin
-for x := 0 to 5 do uos_OutputSetDSPVolume(x, 0, vol/100, vol/100, True);
+if isloaded then for x := 0 to 5 do uos_OutputSetDSPVolume(x, 0, vol/100, vol/100, True);
 end;
    
 procedure Freeuos;


### PR DESCRIPTION
Hello Roland.

I was on Windows 10 and your last commit.

If compiling with `-ghl` and **with** `-WG`, message when close:

> Segmentation fault
> #7  5788 unknown 0x0041d483 in CLASSES$_$TLIST_$__$$_GETCOUNT$$LONGINT ()
> 

But If compiling with `-ghl` and **without** `-WG`,  message when close:

> Heap dump by heaptrc unit
> 7591 memory blocks allocated : 5269445/5286104
> 7591 memory blocks freed     : 5269445/5286104
> 0 unfreed memory blocks : 0
> True heap size : 163840 (96 used in System startup)
> True free heap : 163744
> 

For me there is no more memory leak but a problem with heap-trace in GUI mode.
So, IMHO, it is ok for release.

In the pull-request, some checks to make Eschecs more errors friendly (message if errors).

A very little detail, I commented the message if  `Colored Square` state was changed (cause it is dynamic).
But maybe it was wanted so, sorry for this.

OK, je vous passe la main.

Fre;D  